### PR TITLE
Improve comment template

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -17,7 +17,6 @@ OWNER=""
 XML_FILE=""
 
 # Disqus and site information
-DISQUS_USERNAME=""
 SITE_URL=""
 
 # GitHub category name

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ Follow the next steps to install and configure the script:
 | `OWNER` | The owner ID of the repository |
 | `REPOSITORY` | The repository name |
 | `XML_FILE` | The filename of the Disqus XML export file (this should be placed in the root) |
-| `DISQUS_USERNAME` | The username to exclude from the comment headers (in case you don't want to show your own name) |
 | `SITE_URL` | The site URL to process, this will be used to ignore different starting paths like Google translate, cache, ... |
 | `CATEGORY_NAME` | The name of the discussion category to which the new discussions get created |
 | `API_RETRIES` | The number of retries to make in case of an error |

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,9 @@ if (!process.env.XML_FILE) {
   throw new Error("XML_FILE environment variable is not set");
 }
 
+// Ensure that dates in the imported comments are displayed in UTC
+process.env.TZ = "UTC"
+
 const xmlData = readFileSync(join(__dirname, "../", process.env.XML_FILE), "utf8");
 
 (async () => {

--- a/src/utils/addDiscussionComment.ts
+++ b/src/utils/addDiscussionComment.ts
@@ -36,12 +36,6 @@ export const addDiscussionComment = async (token: string, discussionId: string, 
     }
   })
   const markdown = turndownService.turndown(comment.message);
-
-  let author = comment.author?.name;
-  if (process.env.DISQUS_USERNAME && process.env.DISQUS_USERNAME === comment.author?.username) {
-    author = "";
-  }
-  
   const response: AddDiscussionCommentResponse = await fetch(GRAPHQL_API, {
     method: 'POST',
     headers: {
@@ -65,9 +59,13 @@ export const addDiscussionComment = async (token: string, discussionId: string, 
       `,
       variables: {
         discussionId,
-        body: `\`\`\`header
-Originally posted${author ? ` by ${comment.author.name}` : ""} on ${format(new Date(comment.createdAt), "yyyy-MM-dd HH:mm")}
-\`\`\`
+        body: `<p>
+<img src="https://disqus.com/api/users/avatars/${comment.author.username}.jpg" width="48" height="48" align="left" hspace="10">
+<strong>Posted by <a href="https://disqus.com/by/${comment.author.username}">${comment.author.name}</a></strong>
+<br/>
+<em>${format(date, "EEEE MMM dd, Y 'at' HH:mm 'GMT'")}</em>
+</p>
+<hr/>
 
 ${markdown}
 


### PR DESCRIPTION
- The comment template now includes the user's Disqus avatar, as well as a clickable link to their profile.
- The special case of not showing the admins name has been removed because the inconsistency made conversations hard to follow.
- The "TZ" environment variable is set to "UTC" when the program runs in order to have the dates that are displayed in the comments be in GMT.

In general, the comment template now more clearly communicates that the comment was imported, as well as makes following conversations easier.

Link to a live example of this template being used: https://cmetcalfe.ca/blog/record-audio-from-specific-applications-with-shadowplay.html

Screenshot of a comment chain from the above link that includes a mix of imported and new comments:
![Screen Shot 2024-01-16 at 8 23 43 PM](https://github.com/estruyf/disqus-to-github-discussions/assets/466941/336a9398-6ad1-4fe3-b645-0d6a276e6e2b)
